### PR TITLE
Add template for Alpine Linux 3.5

### DIFF
--- a/alpine3.5/CHANGELOG.md
+++ b/alpine3.5/CHANGELOG.md
@@ -1,0 +1,42 @@
+## [Alpine Linux](http://alpinelinux.org) v3.5
+
+* x86_64
+* virtual install
+* no VBoxGuestAdditions
+* [Packer template](https://github.com/maier/packer-templates/)
+
+## Use
+
+#### Install the [vagrant-alpine](https://github.com/maier/vagrant-alpine) guest plugin.
+
+```
+vagrant plugin install vagrant-alpine
+```
+
+#### Create a `Vagrantfile`:
+
+```
+vagrant init maier/alpine-3.5-x86_64
+```
+
+#### Edit the Vagrantfile to customize for your needs.
+
+* Networking (Until VBGA support)
+   * Add a static private network interface to use shared folders.
+      * e.g. `alpine.vm.network "private_network", ip: "192.168.200.10"`
+* Shared folders (Until VBGA support)
+   * Disable default share if not using shared folders so Vagrant will not block attempting to mount the volume.
+      * `config.vm.synced_folder '.', '/vagrant', disabled: true`
+   * Enable synced folders with `type: 'nfs'`, **requires** static address on private network interface to function.
+
+#### Start the box:
+
+```
+vagrant up
+```
+
+## Changes
+
+* v1.0.0
+   * Initial -- Alpine v3.5.0
+

--- a/alpine3.5/README.md
+++ b/alpine3.5/README.md
@@ -1,0 +1,35 @@
+# [Alpine Linux](http://alpinelinux.org)
+
+* minimal linux distro
+* good for Docker containers [gliderlabs/docker-alpine](https://github.com/gliderlabs/docker-alpine)
+
+Build is for developing and testing what will be run in a container and building Dockerfiles.
+
+* v3.5 `vagrant init maier/alpine-3.5-x86_64`
+
+## Usage notes
+
+Virtualbox Guest Additions do not build/install on v3.5 of Alpine.
+
+* Private network needs be configured as static in Vagrantfile in order to use
+  folder sharing. If it is set to DHCP, Virtualbox will not see the address
+  assigned to the interface, therefore, Vagrant will not be able to retrieve it
+  to configure NFS.
+* Folder sharing should be configured to use NFS in Vagrantfile.
+* `bash` is installed by default so `config.ssh.shell="/bin/sh"` is not necessary.
+* Vagrant plugin `vagrant-alpine` developed to support Alpine specific guest.
+   * `vagrant plugin install vagrant-alpine`.
+   * [Github repository](https://github.com/maier/vagrant-alpine/).
+   * Removed creation of fake `shutdown` command.
+   * Remove installation of `nfs-utils`.
+   * Remove starting `rpc.statd`.
+
+
+## Build environment
+
+```shell
+⁖ packer version && vagrant -v && vboxmanage --version
+Packer v0.12.2
+Vagrant 1.8.5
+5.1.0r108711
+```

--- a/alpine3.5/Vagrantfile
+++ b/alpine3.5/Vagrantfile
@@ -1,0 +1,46 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  config.vm.define "alpine" do |alpine|
+
+    alpine.vm.box = "maier/alpine-3.5-x86_64"
+
+    #alpine.ssh.username = "vagrant"
+    #alpine.ssh.password = "vagrant"
+
+    # NOTE:
+    # 	there are *no* guest additions installed
+    # 	for alpine linux - the guest additions
+    # 	installer fails. once workarounds are
+    # 	identified the vbga will be added
+    # 	to the base box.
+    #
+    # since there are no vbga. if the vagrant-alpine plugin
+    # is installed it can at least configure the system to
+    # enable shared folders.
+    #
+    alpine.vm.synced_folder ".", "/vagrant", disabled: true
+    #
+    # after `vagrant plugin install vagrant-alpine`
+    # comment the disabled synced_folder line above and
+    # uncomment the following two lines
+    #
+    # alpine.vm.network "private_network", ip: "172.28.128.250"
+    # alpine.vm.synced_folder ".", "/vagrant", type: "nfs"
+
+    alpine.vm.provider "virtualbox" do |vb|
+      vb.name = 'Alpine'
+      vb.cpus = 1
+      vb.memory = 1024
+      vb.customize ["modifyvm", :id,
+                    "--natdnshostresolver1", "on",
+                    "--nic1", "nat",
+                    "--cableconnected1", "on"]
+      # Display the VirtualBox GUI when booting the machine
+      # vb.gui = true
+    end
+  end
+
+end

--- a/alpine3.5/alpine-3.5-x86_64.json
+++ b/alpine3.5/alpine-3.5-x86_64.json
@@ -1,0 +1,107 @@
+{
+  "description": "Build base Alpine Linux x86_64",
+  "push": {
+    "name": "maier/alpine35",
+    "vcs": true
+  },
+  "variables": {
+    "atlas_user": "{{env `ATLAS_USER_NAME`}}",
+    "atlas_token": "{{env `ATLAS_TOKEN`}}",
+    "atlas_box": "{{env `ATLAS_BOX_NAME`}}",
+    "disk_size": "10240",
+    "memory": "1024",
+    "cpus": "1"
+  },
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/00base.sh",
+        "scripts/01alpine.sh",
+        "scripts/01networking.sh",
+        "scripts/02sshd.sh",
+        "scripts/03vagrant.sh",
+        "scripts/04sudoers.sh",
+        "scripts/90virtualbox.sh",
+        "scripts/99minimize.sh"
+      ],
+      "override": {
+        "virtualbox-iso": {
+          "execute_command": "/bin/sh '{{.Path}}'"
+        }
+      }
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "virtualbox_version_file": ".vbox_version",
+
+      "guest_additions_mode": "disable",
+      "guest_os_type": "Linux26_64",
+      "headless": false,
+      "disk_size": "{{user `disk_size`}}",
+      "http_directory": "http",
+
+      "iso_urls": ["isos/alpine-virt-3.5.1-x86_64.iso", 
+                   "https://nl.alpinelinux.org/alpine/v3.5/releases/x86_64/alpine-virt-3.5.1-x86_64.iso"],
+      "iso_checksum": "8092b3d482fb1b7a5cf28c43bc1425c8f2d380e86869c0686c49aa7b0f086ab2",
+      "iso_checksum_type": "sha256",
+
+      "communicator": "ssh",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10m",
+      "shutdown_command": "/sbin/poweroff",
+
+      "boot_wait": "30s",
+      "boot_command": [
+        "root<enter><wait>",
+        "ifconfig eth0 up && udhcpc -i eth0<enter><wait>",
+        "wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/answers<enter><wait>",
+        "setup-alpine -f answers<enter><wait5>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "<wait10><wait10><wait10>",
+        "<wait10><wait10><wait10>",
+        "y<enter>",
+        "<wait10><wait10><wait10>",
+        "<wait10><wait10><wait10>",
+        "<wait10><wait10><wait10>",
+        "<wait10><wait10><wait10>",
+        "<wait10><wait10><wait10>",
+        "<wait10><wait10><wait10>",
+        "rc-service sshd stop<enter>",
+        "mount /dev/sda3 /mnt<enter>",
+        "echo 'PermitRootLogin yes' >> /mnt/etc/ssh/sshd_config<enter>",
+        "umount /mnt<enter>",
+        "reboot<enter>"
+      ],
+
+      "hard_drive_interface": "sata",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--memory", "{{user `memory`}}"],
+        ["modifyvm", "{{.Name}}", "--cpus", "{{user `cpus`}}"]
+      ]
+
+    }
+  ],
+  "post-processors": [
+    [{
+      "type": "vagrant",
+      "keep_input_artifact": false
+    },
+    {
+      "type": "atlas",
+      "only": ["virtualbox-iso"],
+      "token": "{{user `atlas_token`}}",
+      "artifact": "{{user `atlas_user`}}/{{user `atlas_box`}}",
+      "artifact_type": "vagrant.box",
+      "metadata": {
+        "provider": "virtualbox",
+        "description": "[Alpine Linux](http://alpinelinux.org) v3.5.1",
+        "version": "1.0.0"
+      }
+    }]
+  ]
+}

--- a/alpine3.5/http/answers
+++ b/alpine3.5/http/answers
@@ -1,0 +1,16 @@
+KEYMAPOPTS="us us"
+HOSTNAMEOPTS="-n alpine35"
+INTERFACESOPTS="auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet dhcp
+    hostname alpine35
+"
+DNSOPTS="-d local -n 8.8.8.8 8.8.4.4"
+TIMEZONEOPTS="-z UTC"
+PROXYOPTS="none"
+APKREPOSOPTS="http://dl-cdn.alpinelinux.org/alpine/v3.5/main"
+SSHDOPTS="-c openssh"
+NTPOPTS="-c openntpd"
+DISKOPTS="-s 0 -m sys /dev/sda"

--- a/alpine3.5/scripts/00base.sh
+++ b/alpine3.5/scripts/00base.sh
@@ -1,0 +1,19 @@
+set -ux
+
+apk upgrade -U --available
+
+source /etc/os-release
+
+cat << EOF > /etc/motd
+
+$PRETTY_NAME ($VERSION_ID) Development Environment
+
+Built for use with Vagrant using:
+   <https://github.com/maier/packer-templates>
+
+See the Alpine Wiki for how-to guides and
+general information about administrating
+Alpine systems and development.
+See <http://wiki.alpinelinux.org>
+
+EOF

--- a/alpine3.5/scripts/01alpine.sh
+++ b/alpine3.5/scripts/01alpine.sh
@@ -1,0 +1,5 @@
+set -ux
+
+# nothing special required
+
+exit 0

--- a/alpine3.5/scripts/01networking.sh
+++ b/alpine3.5/scripts/01networking.sh
@@ -1,0 +1,5 @@
+set -ux
+
+# nothing special required
+
+exit 0

--- a/alpine3.5/scripts/02sshd.sh
+++ b/alpine3.5/scripts/02sshd.sh
@@ -1,0 +1,8 @@
+set -eux
+
+# add in order to allow packer ssh access to provision
+# the system, remove here to make box more secure
+sed -i '/^PermitRootLogin yes/d' /etc/ssh/sshd_config
+
+# make 'vagrant ssh' connections faster
+echo "UseDNS no" >> /etc/ssh/sshd_config

--- a/alpine3.5/scripts/03vagrant.sh
+++ b/alpine3.5/scripts/03vagrant.sh
@@ -1,0 +1,25 @@
+set -exu
+
+date > /etc/vagrant_box_build_time
+
+#
+# bash for vagrant (default shell is bash)
+#   doesn't look like there is an easy way for vagrant guest
+#   plugin to register a default shell. easier than always
+#   having to *remember* to configure `ssh.shell` for
+#   alpine boxes.
+#
+# cURL for initial vagrant key install from vagrant github repo.
+#   on first 'vagrant up', overwritten with a local, secure key.
+#
+apk add bash curl
+
+adduser -D vagrant
+echo "vagrant:vagrant" | chpasswd
+
+mkdir -pm 700 /home/vagrant/.ssh
+
+curl -sSo /home/vagrant/.ssh/authorized_keys 'https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub'
+
+chown -R vagrant:vagrant /home/vagrant/.ssh
+chmod -R go-rwsx /home/vagrant/.ssh

--- a/alpine3.5/scripts/04sudoers.sh
+++ b/alpine3.5/scripts/04sudoers.sh
@@ -1,0 +1,7 @@
+set -eux
+
+apk add sudo
+adduser vagrant wheel
+
+echo "Defaults exempt_group=wheel" > /etc/sudoers
+echo "%wheel ALL=NOPASSWD:ALL" >> /etc/sudoers

--- a/alpine3.5/scripts/90virtualbox.sh
+++ b/alpine3.5/scripts/90virtualbox.sh
@@ -1,0 +1,53 @@
+set -eux
+echo "VBoxGuestAdditions currently do not build or install on Alpine Linux."
+exit 0
+#
+# #
+# # VBoxGuestAdditions fails to install.
+# #
+# # Alpine is intended to be 'minimal' so
+# # there are certain things VBGA
+# # 1. needs
+# # 2. *assumes* are available
+# # 3. or function a specific way
+# # which is, not yet, the case...
+# #
+#
+# mkdir -p /mnt/virtualbox
+# retval=$?
+# [ $retval -eq 0 ] || exit $retval
+#
+# modprobe loop
+# retval=$?
+# [ $retval -eq 0 ] || exit $retval
+#
+# LOOP=`losetup -f`
+# retval=$?
+# [ $retval -eq 0 ] || exit $retval
+#
+# losetup $LOOP /root/VBoxGuestAdditions.iso
+# retval=$?
+# [ $retval -eq 0 ] || exit $retval
+#
+# mount -t iso9660 -o ro $LOOP /mnt/virtualbox
+# retval=$?
+# [ $retval -eq 0 ] || exit $retval
+#
+# # current error 'unable to determine library path.'
+# # "ldconfig -v" does not result in a list of valid
+# # library paths (it is actually a shell script which
+# # silently ignores -v).
+# #
+# # there are other issues as well, which have been
+# # open with oracle/virtualbox for several years.
+# # without forward progress (according to search
+# # results and skimming through various discussions).
+# sh /mnt/virtualbox/VBoxLinuxAdditions.run
+# retval=$?
+# [ $retval -eq 0 ] || exit $retval
+#
+# ln -s /opt/VBoxGuestAdditions-*/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions
+# umount /mnt/virtualbox
+# rm -rf /root/VBoxGuestAdditions.iso
+#
+# # END

--- a/alpine3.5/scripts/99minimize.sh
+++ b/alpine3.5/scripts/99minimize.sh
@@ -1,0 +1,11 @@
+set -ux
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY
+# Block until the empty file has been removed, otherwise, Packer
+# will try to kill the box while the disk is still full and that's bad
+sync
+sync
+sync
+
+exit 0

--- a/alpine3.5/sh_vars
+++ b/alpine3.5/sh_vars
@@ -1,0 +1,16 @@
+
+dist_name="alpine"
+dist_vers="3.4"
+dist_arch="x86_64"
+
+# local or remote
+build_type="local"
+
+# set in .bashrc
+# ATLAS_USER_NAME="maier"
+# ATLAS_TOKEN="abcd.not.a.real.token"
+#
+# default in atlas.sh is fine
+# ATLAS_BOX_NAME="${dist_name}-${dist_vers}-${dist_arch}"
+
+# END


### PR DESCRIPTION
This adds templates for Alpine Linux 3.5, and was based very strongly on the Alpine 3.4 templates. VirtualBox guest additions still don't seem to be working reliably, so those haven't been added in this version.

I've built and [pushed the box to Atlas](https://atlas.hashicorp.com/nastevens/boxes/alpine-3.5-x86_64/versions/3.5.1) so there at least aren't any glaring flaws.
